### PR TITLE
Add monitoring multiple replications

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,45 @@ Where config.json might look something like:
 }
 ```
 
+or for multiple replications:
+
+```json
+[
+  {
+      "couchUrl"       : "http://my.npm.mirror.foo.com:5984"
+    , "couchUser"      : "admin"
+    , "couchPass"      : "fs98dkKHs87lasl"
+    , "db"             : "registry"
+    , "checkInterval"  : 3600000
+    , "replicationDoc" : {
+          "source"     : "https://fullfatdb.npmjs.com/registry"
+        , "target"     : "registry"
+        , "continuous" : true
+        , "user_ctx"   : {
+              "name"  : "admin"
+            , "roles" : [ "_admin" ]
+         }
+      }
+  },
+  {
+      "couchUrl"       : "http://my.npm.mirror.foo.com:5984"
+    , "couchUser"      : "admin"
+    , "couchPass"      : "fs98dkKHs87lasl"
+    , "db"             : "registry2"
+    , "checkInterval"  : 3600000
+    , "replicationDoc" : {
+          "source"     : "https://fullfatdb.npmjs.com/registry2"
+        , "target"     : "registry2"
+        , "continuous" : true
+        , "user_ctx"   : {
+              "name"  : "admin"
+            , "roles" : [ "_admin" ]
+         }
+      }
+  },
+]
+```
+
 You need to ensure that you have an existing *_replicator* entry named `"registry"` for this to work.
 
 ## What?

--- a/npm-replicator-monitor.js
+++ b/npm-replicator-monitor.js
@@ -13,46 +13,69 @@ if (!argv.c || !fs.existsSync(argv.c)) {
 
 
 var config     = JSON.parse(fs.readFileSync(argv.c))
-  , replicator = new CouchReplicator(config.couchUrl, config.couchUser, config.couchPass, config.db)
-  , lastCheckpoint
+  , checks = []
 
-
-function check () {
-  replicator.status(function (err, status) {
+/**
+ * Runs check for replication identified by [id]
+ * @function check
+ * @param {number} id - The [id] of the check
+ * @returns {Void}
+ */
+function check (id) {
+  checks[id].replicator.status(function (err, status) {
     if (err)
-      return console.error('Got error from status:', err.message)
+      return console.error('Got error from status: %s [%s %s]', err.message, checks[id].config.db, checks[id].config.couchUrl)
 
     if (status.checkpointed_source_seq == status.source_seq) {
-      console.log('Replication up to date')
-      lastCheckpoint = null
+      console.log('Replication up to date [%s %s]', checks[id].config.db, checks[id].config.couchUrl)
+      checks[id].lastCheckpoint = null
       return // all good!
     }
 
-    if (status.checkpointed_source_seq != lastCheckpoint) {
-      console.log('Checkpoint changed since last check, was', lastCheckpoint, 'now', status.checkpointed_source_seq)
-      lastCheckpoint = status.checkpointed_source_seq
+    if (status.checkpointed_source_seq != checks[id].lastCheckpoint) {
+      console.log('Checkpoint changed since last check, was %d now %d [%s %s]', checks[id].lastCheckpoint, status.checkpointed_source_seq, checks[id].config.db, checks[id].config.couchUrl)
+      checks[id].lastCheckpoint = status.checkpointed_source_seq
       return // something has changed
     }
 
     // nothing has changed, time to bump!
-    console.log('Giving the replicator a jolt...')
-    lastCheckpoint = null
-    replicator.del(function (err) {
+    console.log('Giving the replicator a jolt... [%s %s]', checks[id].config.db, checks[id].config.couchUrl)
+    checks[id].lastCheckpoint = null
+    checks[id].replicator.del(function (err) {
       if (err)
-        return console.error('Got error deleting replication doc:', err.message)
+        return console.error('Got error deleting replication doc: %s [%s %s]', err.message, checks[id].config.db, checks[id].config.couchUrl)
 
       setTimeout(function () {
         // Add a new Date so we ensure the rev is different (helps with determinism)
-        var doc = xtend(config.replicationDoc, { created_at_date: new Date() })
-        replicator.put(doc, function (err) {
+        var doc = xtend(checks[id].config.replicationDoc, { created_at_date: new Date() })
+        checks[id].replicator.put(doc, function (err) {
           if (err)
-            return console.error('Error adding replication doc:', err.message)
+            return console.error('Error adding replication doc:%s [%s %s]', err.message, checks[id].config.db, checks[id].config.couchUrl)
         })
       }, 2000) // give it a moment to think
     })
   })
 }
 
+/**
+ * Starts the application
+ * @function main
+ * @returns {Void}
+ */
+function main () {
+  if (!Array.isArray(config))
+    config = [config] // Maintain backward compatibility for single replications in config
 
-setInterval(check, config.checkInterval)
-check()
+  for (var id in config) {
+  	checks[id] = {}
+    checks[id].replicator = new CouchReplicator(config[id].couchUrl, config[id].couchUser, config[id].couchPass, config[id].db)
+    checks[id].lastCheckpoint = null
+    checks[id].config = config[id]
+    setInterval(check.bind(null, id), config[id].checkInterval)
+    check(id)
+    console.log('Started replication checks [%s %s]', config[id].db, config[id].couchUrl);
+  }
+  return;
+}
+
+main()


### PR DESCRIPTION
Allows monitoring multiple couch servers or database replications.

config.json:
- Change to array with multiple objects (objects have the same format as before)
- Keep backwards compatibility with single replication object

npm-replicator-monitor.js:
- Add JSDoc to main and check function
- Add main function to start all replication checks
- Change check function to allow multiple checks to run